### PR TITLE
Improve `getCommands` utility

### DIFF
--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -6,6 +6,28 @@ export function trim(payload: string): string {
   return payload.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
 }
 
+export function toKebabCase(payload: string): string {
+  // Replace whitespace with hyphens
+  let result = payload.replace(/\s+/g, '-');
+
+  // Replace problematic symbols
+  result = result.replace(/\//g, '-').replace(/\\/g, '-');
+
+  // Remove any characters that are not alphanumeric or hyphens
+  result = result.replace(/[^a-zA-Z0-9-]/g, '');
+
+  // Convert to lowercase
+  result = result.toLowerCase();
+
+  // Remove leading/trailing hyphens
+  result = result.replace(/^-+|-+$/g, '');
+
+  // Replace multiple consecutive hyphens with a single hyphen
+  result = result.replace(/-+/g, '-');
+
+  return result;
+}
+
 export function toTitleCase(payload: string): string {
   const formattedTitle = trim(payload).toLowerCase();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
   renameFile,
 } from './features';
 import { ctx, logger, wait } from './lib';
-import { getCommand, getIsSuggestionElementActive } from './obsidian';
+import { getCommand, getIsSuggestionElementActive, ICommand } from './obsidian';
 
 export default class Denote extends Plugin {
   readonly app: App;
@@ -30,50 +30,17 @@ export default class Denote extends Plugin {
   }
 
   private setCommands(): void {
-    this.addCommand(
-      getCommand({
-        id: 'format-heading',
-        name: 'Format Heading',
+    const commands: ICommand[] = [
+      { name: 'Format Heading', callback: formatHeadings },
+      { name: 'Rename File', callback: renameFile },
+      { name: 'Format Front Matter', callback: formatFrontMater },
+      { name: 'Fuzzy Find BackLinks', callback: fuzzyFindBackLinks },
+      { name: 'Fuzzy Find Outgoing Links', callback: fuzzyFindOutgoingLinks },
+    ];
 
-        callback: formatHeadings,
-      }),
-    );
-
-    this.addCommand(
-      getCommand({
-        id: 'rename-file',
-        name: 'Rename File',
-
-        callback: renameFile,
-      }),
-    );
-
-    this.addCommand(
-      getCommand({
-        id: 'format-front-matter',
-        name: 'Format Front Matter',
-
-        callback: formatFrontMater,
-      }),
-    );
-
-    this.addCommand(
-      getCommand({
-        id: 'fuzzy-find-backlinks',
-        name: 'Fuzzy Find BackLinks',
-
-        callback: fuzzyFindBackLinks,
-      }),
-    );
-
-    this.addCommand(
-      getCommand({
-        id: 'fuzzy-find-outgoing-links',
-        name: 'Fuzzy Find Outgoing Links',
-
-        callback: fuzzyFindOutgoingLinks,
-      }),
-    );
+    commands.forEach((command) => {
+      this.addCommand(getCommand(command));
+    });
   }
 
   private setEvents(): void {

--- a/src/obsidian/command.ts
+++ b/src/obsidian/command.ts
@@ -2,7 +2,7 @@ import { Command } from 'obsidian';
 
 import { toKebabCase, toTitleCase } from 'src/lib';
 
-interface Payload {
+export interface ICommand {
   name: string;
 
   callback: () => any;
@@ -10,9 +10,9 @@ interface Payload {
 
 const COMMAND_PREFIX = 'denote';
 
-export function getCommand(payload: Payload): Command {
+export function getCommand(payload: ICommand): Command {
   return {
-    ...payload,
+    callback: payload.callback,
     id: `${COMMAND_PREFIX}--${toKebabCase(payload.name)}`,
     name: `${toTitleCase(payload.name)} Command`,
   };

--- a/src/obsidian/command.ts
+++ b/src/obsidian/command.ts
@@ -1,7 +1,8 @@
 import { Command } from 'obsidian';
 
+import { toKebabCase, toTitleCase } from 'src/lib';
+
 interface Payload {
-  id: string;
   name: string;
 
   callback: () => any;
@@ -12,7 +13,7 @@ const COMMAND_PREFIX = 'denote';
 export function getCommand(payload: Payload): Command {
   return {
     ...payload,
-    id: `${COMMAND_PREFIX}--${payload.id}`,
-    name: `${payload.name} Command`,
+    id: `${COMMAND_PREFIX}--${toKebabCase(payload.name)}`,
+    name: `${toTitleCase(payload.name)} Command`,
   };
 }


### PR DESCRIPTION
## :dart: Objectives

- [x] Standardize to use `toKebabCase` for command `id`.
- [x] Standardize to use `toTitleCase` for command `name`.
- [x] Refactor the command instance to be more declaritive.